### PR TITLE
LK: reinstated text in open_jdk_jre.yml

### DIFF
--- a/config/open_jdk_jre.yml
+++ b/config/open_jdk_jre.yml
@@ -15,4 +15,27 @@
 
 # Configuration for JRE repositories keyed by vendor
 # If Java 7 is required, permgen will be used instead of metaspace. Please see the documentation for more detail.
---- {}
+---
+jre:
+  version: 1.7.0_+
+  repository_root: ! '{default.repository.root}/openjdk/{platform}/{architecture}'
+memory_calculator:
+  version: 2.0.1_RELEASE
+  repository_root: ! '{default.repository.root}/memory-calculator/{platform}/{architecture}'
+  stack_threads:
+  memory_sizes:
+    heap: 64m..256m
+    metaspace: 64m..
+    native:
+    permgen: 64m..
+    stack:
+  memory_heuristics:
+    heap: 75
+    metaspace: 10
+    native: 10
+    permgen: 10
+    stack: 5
+  memory_initials:
+    heap: 100%
+    metaspace: 100%
+    permgen: 100%


### PR DESCRIPTION
it magically disappeared in one of the previous commits.
Doublechecked with yml validator for validity.