### PR TITLE
Add AppD with HTTP Proxy support

### DIFF
--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -16,8 +16,9 @@
 # Configuration for the AppDynamics framework
 ---
 version: 4.+
-repository_root: ""
-default_application_name:
+repository_root: "https://packages.appdynamics.com/java"
+default_application_name: $(ruby -e "require 'json' ; a = JSON.parse(ENV['VCAP_APPLICATION']);
+  puts \"#{a['space_name']}:#{a['application_name']}\"")
 default_node_name: $(ruby -e "require 'json' ; a = JSON.parse(ENV['VCAP_APPLICATION']);
   puts \"#{a['application_name']}:#{a['instance_index']}\"")
 default_tier_name:

--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -15,8 +15,8 @@
 
 # Configuration for the AppDynamics framework
 ---
-version: 4.2.15_2
-repository_root: "https://packages.appdynamics.com/java"
+version: 4.2.7_1
+repository_root: "https://s3-eu-west-1.amazonaws.com/shop-pipeline/appd"
 default_application_name: $(ruby -e "require 'json' ; a = JSON.parse(ENV['VCAP_APPLICATION']);
   puts \"#{a['space_name']}:#{a['application_name']}\"")
 default_node_name: $(ruby -e "require 'json' ; a = JSON.parse(ENV['VCAP_APPLICATION']);

--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -15,7 +15,7 @@
 
 # Configuration for the AppDynamics framework
 ---
-version: 4.2.7
+version: 4.2.15_2
 repository_root: "https://packages.appdynamics.com/java"
 default_application_name: $(ruby -e "require 'json' ; a = JSON.parse(ENV['VCAP_APPLICATION']);
   puts \"#{a['space_name']}:#{a['application_name']}\"")

--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -15,7 +15,7 @@
 
 # Configuration for the AppDynamics framework
 ---
-version: 4.+
+version: 4.2.7
 repository_root: "https://packages.appdynamics.com/java"
 default_application_name: $(ruby -e "require 'json' ; a = JSON.parse(ENV['VCAP_APPLICATION']);
   puts \"#{a['space_name']}:#{a['application_name']}\"")

--- a/config/components.yml
+++ b/config/components.yml
@@ -39,7 +39,7 @@ jres:
 # command after any Java Opts added by previous frameworks.
 
 frameworks:
-# - "JavaBuildpack::Framework::AppDynamicsAgent"
+  - "JavaBuildpack::Framework::AppDynamicsAgent"
   - "JavaBuildpack::Framework::ContainerCertificateTrustStore"
   - "JavaBuildpack::Framework::ContainerCustomizer"
   - "JavaBuildpack::Framework::Debug"

--- a/config/oracle_jre.yml
+++ b/config/oracle_jre.yml
@@ -20,7 +20,7 @@
 # e.g.  repository_root: "http://example.com/oracle-jre/{platform}/{architecture}"
 ---
 jre:
-  version: 1.8.0_12+
+  version: 1.8.0_13+
   repository_root: "https://s3-eu-west-1.amazonaws.com/shop-pipeline"
 memory_calculator:
   version: 2.+

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -117,22 +117,22 @@ module JavaBuildpack
       end
 
       def proxy_host(java_opts, proxy_credentials)
-        host = @proxy_credentials['host']
+        host = proxy_credentials['host']
         java_opts.add_system_property('appdynamics.http.proxyHost', host.to_s) if !host.nil?
       end
 
       def proxy_user(java_opts, proxy_credentials)
-        user = @proxy_credentials['user']
+        user = proxy_credentials['user']
         java_opts.add_system_property('appdynamics.http.proxyHost', user.to_s) if !user.nil?
       end
 
       def proxy_password(java_opts, proxy_credentials)
-        password = @proxy_credentials['password']
+        password = proxy_credentials['password']
         java_opts.add_system_property('appdynamics.http.proxyHost', password.to_s) if !password.nil?
       end
 
       def proxy_port(java_opts, proxy_credentials)
-        port = @proxy_credentials['port']
+        port = proxy_credentials['port']
         java_opts.add_system_property('appdynamics.http.proxyHost', port.to_s) if !port.nil?
       end
 

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -45,8 +45,8 @@ module JavaBuildpack
         host_name java_opts, credentials
         port java_opts, credentials
         ssl_enabled java_opts, credentials
-        
-        if proxy_credentials
+
+        if !proxy_credentials.nil? && !proxy_credentials.empty?
           proxy_host java_opts, proxy_credentials
           proxy_port java_opts, proxy_credentials
           proxy_user java_opts, proxy_credentials
@@ -65,7 +65,7 @@ module JavaBuildpack
 
       FILTER = /app[-]?dynamics/
       PROXY_FILTER = /proxy/
-      
+
       private_constant :FILTER
       private_constant :PROXY_FILTER
 

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -45,7 +45,7 @@ module JavaBuildpack
         port java_opts, credentials
         ssl_enabled java_opts, credentials
 
-        if !@application.services.find_service(FILTER).nil?
+        if !@application.services.find_service(PROXY_FILTER).nil?
           proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
           proxy_host java_opts, proxy_credentials
           proxy_port java_opts, proxy_credentials

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -58,9 +58,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        found = @application.services.one_service? FILTER, 'host-name'
-        puts "Checking AppD Support: " + fount.to_s
-        found
+        @application.services.one_service? FILTER, 'host-name'
       end
 
       private

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -33,7 +33,6 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
         credentials = @application.services.find_service(FILTER)['credentials']
-        proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
         java_opts   = @droplet.java_opts
         java_opts.add_javaagent(@droplet.sandbox + 'javaagent.jar')
 
@@ -46,7 +45,8 @@ module JavaBuildpack
         port java_opts, credentials
         ssl_enabled java_opts, credentials
 
-        if !proxy_credentials.nil? && !proxy_credentials.empty?
+        if !@application.services.find_service(FILTER).nil?
+          proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
           proxy_host java_opts, proxy_credentials
           proxy_port java_opts, proxy_credentials
           proxy_user java_opts, proxy_credentials

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -44,6 +44,12 @@ module JavaBuildpack
         host_name java_opts, credentials
         port java_opts, credentials
         ssl_enabled java_opts, credentials
+        
+        java_opts.add_system_property('appdynamics.http.proxyHost', '$WEB_PROXY_HOST') if !proxy_host.nil? && !proxy_host.empty?
+        java_opts.add_system_property('appdynamics.http.proxyUser', '$WEB_PROXY_USER') if !proxy_user.nil? && !proxy_user.empty?
+        java_opts.add_system_property('appdynamics.http.proxyPassword', '$WEB_PROXY_PASS') if !proxy_password.nil? && !proxy_password.empty?
+        java_opts.add_system_property('appdynamics.http.proxyPort', '$WEB_PROXY_PORT') if !proxy_port.nil?
+
       end
 
       protected
@@ -100,6 +106,22 @@ module JavaBuildpack
         name = credentials['tier-name'] || @configuration['default_tier_name'] ||
           @application.details['application_name']
         java_opts.add_system_property('appdynamics.agent.tierName', name.to_s)
+      end
+
+      def proxy_host
+        @application.services.find_service(PROXY_FILTER)['credentials']['host']
+      end
+
+      def proxy_user
+        @application.services.find_service(PROXY_FILTER)['credentials']['username']
+      end
+
+      def proxy_password
+        @application.services.find_service(PROXY_FILTER)['credentials']['password']
+      end
+
+      def proxy_port
+        @application.services.find_service(PROXY_FILTER)['credentials']['port']
       end
 
     end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -33,7 +33,7 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
         credentials = @application.services.find_service(FILTER)['credentials']
-        proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
+        # proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
         java_opts   = @droplet.java_opts
         java_opts.add_javaagent(@droplet.sandbox + 'javaagent.jar')
 
@@ -46,7 +46,6 @@ module JavaBuildpack
         port java_opts, credentials
         ssl_enabled java_opts, credentials
         
-        set_logs_dir java_opts
       end
 
       protected
@@ -106,11 +105,6 @@ module JavaBuildpack
           @application.details['application_name']
         java_opts.add_system_property('appdynamics.agent.tierName', name.to_s)
       end
-
-      def set_logs_dir(java_opts)
-        java_opts.add_system_property('appdynamics.agent.logs.dir ', @droplet.sandbox + 'logs')
-      end
-
     end
 
   end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -33,7 +33,6 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
         credentials = @application.services.find_service(FILTER)['credentials']
-        # proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
         java_opts   = @droplet.java_opts
         java_opts.add_javaagent(@droplet.sandbox + 'javaagent.jar')
 
@@ -46,6 +45,10 @@ module JavaBuildpack
         port java_opts, credentials
         ssl_enabled java_opts, credentials
         
+        @droplet.java_opts.add_system_property('appdynamics.http.proxyHost', '$WEB_PROXY_HOST') if !proxy_host.nil? && !proxy_host.empty?
+        @droplet.java_opts.add_system_property('appdynamics.http.proxyUser', '$WEB_PROXY_USER') if !proxy_user.nil? && !proxy_user.empty?
+        @droplet.java_opts.add_system_property('appdynamics.http.proxyPort', '$WEB_PROXY_PORT') if !proxy_port.nil?
+        @droplet.java_opts.add_system_property('appdynamics.http.proxyPassword', '$WEB_PROXY_PASS') if !proxy_password.nil? && !proxy_password.empty?
       end
 
       protected
@@ -104,6 +107,22 @@ module JavaBuildpack
         name = credentials['tier-name'] || @configuration['default_tier_name'] ||
           @application.details['application_name']
         java_opts.add_system_property('appdynamics.agent.tierName', name.to_s)
+      end
+
+      def proxy_host
+        @application.services.find_service(PROXY_FILTER)['credentials']['host']
+      end
+
+      def proxy_user
+        @application.services.find_service(PROXY_FILTER)['credentials']['username']
+      end
+
+      def proxy_password
+        @application.services.find_service(PROXY_FILTER)['credentials']['password']
+      end
+
+      def proxy_port
+        @application.services.find_service(PROXY_FILTER)['credentials']['port']
       end
     end
 

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -62,8 +62,10 @@ module JavaBuildpack
       private
 
       FILTER = /app[-]?dynamics/
-
+      PROXY_FILTER = /proxy/
+      
       private_constant :FILTER
+      private_constant :PROXY_FILTER
 
       def application_name(java_opts, credentials)
         name = credentials['application-name'] || @configuration['default_application_name'] ||

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -58,7 +58,9 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER, 'host-name'
+        found = @application.services.one_service? FILTER, 'host-name'
+        puts "Checking AppD Support: " + fount.to_s
+        found
       end
 
       private

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -46,10 +46,12 @@ module JavaBuildpack
         port java_opts, credentials
         ssl_enabled java_opts, credentials
         
-        proxy_host java_opts, proxy_credentials
-        proxy_port java_opts, proxy_credentials
-        proxy_user java_opts, proxy_credentials
-        proxy_password_file java_opts, proxy_credentials
+        if proxy_credentials
+          proxy_host java_opts, proxy_credentials
+          proxy_port java_opts, proxy_credentials
+          proxy_user java_opts, proxy_credentials
+          proxy_password_file java_opts, proxy_credentials
+        end
       end
 
       protected

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -44,6 +44,7 @@ module JavaBuildpack
         host_name java_opts, credentials
         port java_opts, credentials
         ssl_enabled java_opts, credentials
+        set_logs_dir java_opts
         
         java_opts.add_system_property('appdynamics.http.proxyHost', '$WEB_PROXY_HOST') if !proxy_host.nil? && !proxy_host.empty?
         java_opts.add_system_property('appdynamics.http.proxyUser', '$WEB_PROXY_USER') if !proxy_user.nil? && !proxy_user.empty?
@@ -108,6 +109,10 @@ module JavaBuildpack
         name = credentials['tier-name'] || @configuration['default_tier_name'] ||
           @application.details['application_name']
         java_opts.add_system_property('appdynamics.agent.tierName', name.to_s)
+      end
+
+      def set_logs_dir(java_opts)
+        java_opts.add_system_property('appdynamics.agent.logs.dir ', @droplet.sandbox + 'logs')
       end
 
       def proxy_host

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -46,11 +46,6 @@ module JavaBuildpack
         port java_opts, credentials
         ssl_enabled java_opts, credentials
         
-        proxy_host java_opts, proxy_credentials
-        proxy_port java_opts, proxy_credentials
-        proxy_user java_opts, proxy_credentials
-        proxy_password java_opts, proxy_credentials
-
         set_logs_dir java_opts
       end
 
@@ -114,26 +109,6 @@ module JavaBuildpack
 
       def set_logs_dir(java_opts)
         java_opts.add_system_property('appdynamics.agent.logs.dir ', @droplet.sandbox + 'logs')
-      end
-
-      def proxy_host(java_opts, proxy_credentials)
-        host = proxy_credentials['host']
-        java_opts.add_system_property('appdynamics.http.proxyHost', host.to_s) if !host.nil?
-      end
-
-      def proxy_user(java_opts, proxy_credentials)
-        user = proxy_credentials['user']
-        java_opts.add_system_property('appdynamics.http.proxyHost', user.to_s) if !user.nil?
-      end
-
-      def proxy_password(java_opts, proxy_credentials)
-        password = proxy_credentials['password']
-        java_opts.add_system_property('appdynamics.http.proxyHost', password.to_s) if !password.nil?
-      end
-
-      def proxy_port(java_opts, proxy_credentials)
-        port = proxy_credentials['port']
-        java_opts.add_system_property('appdynamics.http.proxyHost', port.to_s) if !port.nil?
       end
 
     end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -33,6 +33,7 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
         credentials = @application.services.find_service(FILTER)['credentials']
+        proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
         java_opts   = @droplet.java_opts
         java_opts.add_javaagent(@droplet.sandbox + 'javaagent.jar')
 
@@ -44,13 +45,13 @@ module JavaBuildpack
         host_name java_opts, credentials
         port java_opts, credentials
         ssl_enabled java_opts, credentials
-        set_logs_dir java_opts
         
-        java_opts.add_system_property('appdynamics.http.proxyHost', '$WEB_PROXY_HOST') if !proxy_host.nil? && !proxy_host.empty?
-        java_opts.add_system_property('appdynamics.http.proxyUser', '$WEB_PROXY_USER') if !proxy_user.nil? && !proxy_user.empty?
-        java_opts.add_system_property('appdynamics.http.proxyPassword', '$WEB_PROXY_PASS') if !proxy_password.nil? && !proxy_password.empty?
-        java_opts.add_system_property('appdynamics.http.proxyPort', '$WEB_PROXY_PORT') if !proxy_port.nil?
+        proxy_host java_opts, proxy_credentials
+        proxy_port java_opts, proxy_credentials
+        proxy_user java_opts, proxy_credentials
+        proxy_password java_opts, proxy_credentials
 
+        set_logs_dir java_opts
       end
 
       protected
@@ -115,20 +116,24 @@ module JavaBuildpack
         java_opts.add_system_property('appdynamics.agent.logs.dir ', @droplet.sandbox + 'logs')
       end
 
-      def proxy_host
-        @application.services.find_service(PROXY_FILTER)['credentials']['host']
+      def proxy_host(java_opts, proxy_credentials)
+        host = @proxy_credentials['host']
+        java_opts.add_system_property('appdynamics.http.proxyHost', host.to_s) if !host.nil?
       end
 
-      def proxy_user
-        @application.services.find_service(PROXY_FILTER)['credentials']['username']
+      def proxy_user(java_opts, proxy_credentials)
+        user = @proxy_credentials['user']
+        java_opts.add_system_property('appdynamics.http.proxyHost', user.to_s) if !user.nil?
       end
 
-      def proxy_password
-        @application.services.find_service(PROXY_FILTER)['credentials']['password']
+      def proxy_password(java_opts, proxy_credentials)
+        password = @proxy_credentials['password']
+        java_opts.add_system_property('appdynamics.http.proxyHost', password.to_s) if !password.nil?
       end
 
-      def proxy_port
-        @application.services.find_service(PROXY_FILTER)['credentials']['port']
+      def proxy_port(java_opts, proxy_credentials)
+        port = @proxy_credentials['port']
+        java_opts.add_system_property('appdynamics.http.proxyHost', port.to_s) if !port.nil?
       end
 
     end


### PR DESCRIPTION
This change adds AppD agent support along with proxy configuration, should be self explanatory. 

For this to work you need to bind a user provided service with the appropriate credentials and configuration for AppD, and a Proxy if required. 