### PR TITLE
Enable Automatic Notifications via AppD.

### DIFF
--- a/config/version.yml
+++ b/config/version.yml
@@ -1,2 +1,2 @@
 ---
-version: v3.6
+version: v4-sky

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -105,7 +105,7 @@ module JavaBuildpack
             
             events_uri.query = URI.encode_www_form(
             'eventtype' => 'APPLICATION_DEPLOYMENT',
-            'summary' => URI.encode("Deploying: #{app_name}"),
+            'summary' => "Deploying: #{app_name} into #{appd_name}",
             'severity' => 'INFO'
             )
               

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -91,6 +91,7 @@ module JavaBuildpack
       # tell appd about this release.
       def deployment_notifier(api_credentials, credentials)
         @logger.debug("-----> Trying AppD Deployment Notification.")
+        @logger.debug(api_credentials)
         if api_credentials['username'] and api_credentials['password']
             @logger.debug("----> Making Request");
             host_name = credentials['host-name']

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -117,7 +117,7 @@ module JavaBuildpack
               res = proxy.start(events_uri.host, events_uri.port) do |http|
                 http.request(request)
               end
-              @logger.debug(res.body)g
+              @logger.debug(res.body)
             else
               sock = Net::HTTP.new(events_uri.host, events_uri.port)
               sock.use_ssl = true

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -46,7 +46,6 @@ module JavaBuildpack
         host_name java_opts, credentials
         port java_opts, credentials
         ssl_enabled java_opts, credentials
-        deployment_notifier credentials
 
         if !@application.services.find_service(PROXY_FILTER).nil?
           proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
@@ -54,6 +53,11 @@ module JavaBuildpack
           proxy_port java_opts, proxy_credentials
           proxy_user java_opts, proxy_credentials
           proxy_password_file java_opts, proxy_credentials
+        end
+
+        # Do Event Notification if we have API Credentials.
+        if !@application.services.find_service(API_FILTER).nil?
+          deployment_notifier @application.services.find_service(API_FILTER)['credentials'] credentials
         end
       end
 
@@ -66,37 +70,39 @@ module JavaBuildpack
 
       private
 
+      API_FILTER = /appd-api/
       FILTER = /app[-]?dynamics/
       PROXY_FILTER = /proxy/
 
       private_constant :FILTER
       private_constant :PROXY_FILTER
+      private_constant :API_FILTER
       
       # If api-user api-name are set on credenitals and appd-build set in env.
       # tell appd about this release.
-      def deployment_notifier(credentials)
+      def deployment_notifier(api_credentials, credentials)
         
-        if credentials['api-user'] and credentials ['api-password']
-            api_auth = credentials['api-auth']
+        if api_credentials['username'] and api_credentials['password']
             host_name = credentials['host-name']
-            tier_name = credentials['tier-name'] || @configuration['default_tier_name'] || @application.details['application_name']
-            summary = "Deployed Build ID: ${BUILD_ID}"
-            comment = "Comment"
-
-            events_uri = URI.parse("https://$host_name:$port/$app_name/events")
+            port = credentials['port']
+            app_name = credentials['application-name'] || @configuration['default_application_name'] || @application.details['application_name']
+            protocol = (credentials['ssl-enabled']) ? 'https' : 'http';
+            api_user = api_credentials['username']
+            account = credentials['account-name']
+            
+            events_uri = URI.parse("#{protocol}://#{host_name}:#{port}/#{app_name}/events")
             request = Net::HTTP::Post.new(events_uri.path)
-            request.basic_auth "credentials['api-user']@credentials['account-name']", credentials['api-password']
+            request.basic_auth "#{api_user}@#{account}", api_credentials['password']
             request.set_form_data({
               'eventtype' => 'APPLICATION_DEPLOYMENT',
-              'summary' => "Deployed: $app_name",
-              'severity' => "INFO"
+              'summary' => "Deploying: #{app_name}",
+              'severity' => 'INFO'
             })
             
             sock = Net::HTTP.new(events_uri.host, events_uri.port)
             sock.use_ssl = true
             res = sock.start { |http| http.request(req) }
             
-            # Debug LOG.
         end
       end
       

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -114,6 +114,7 @@ module JavaBuildpack
               @logger.debug("Using Proxy to call AppD API.")
               proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
               proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'])
+              proxy.use_ssl = true
               res = proxy.start(events_uri.host, events_uri.port) do |http|
                 http.request(request)
               end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -113,6 +113,7 @@ module JavaBuildpack
             if !@application.services.find_service(PROXY_FILTER).nil?
               @logger.debug("Using Proxy to call AppD API.")
               proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
+              @logger.debug(proxy_credentials)
               proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'])
               res = proxy.start(events_uri.host, events_uri.port, :use_ssl => events_uri.scheme == 'https') do |http|
                 http.request(request)

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -95,12 +95,13 @@ module JavaBuildpack
             @logger.debug("----> Making Request");
             host_name = credentials['host-name']
             port = credentials['port']
+            appd_name = credentials['app-name']
             app_name = credentials['tier-name'] || @configuration['default_application_name'] || @application.details['application_name']
             protocol = 'https';
             api_user = api_credentials['username']
             account = credentials['account-name']
             
-            events_uri = URI.parse("#{protocol}://#{host_name}:#{port}/controller/rest/applications/#{app_name}/events")
+            events_uri = URI.parse("#{protocol}://#{host_name}:#{port}/controller/rest/applications/#{appd_name}/events")
             
             events_uri.query = URI.encode_www_form(
             'eventtype' => 'APPLICATION_DEPLOYMENT',

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -113,8 +113,7 @@ module JavaBuildpack
             if !@application.services.find_service(PROXY_FILTER).nil?
               @logger.debug("Using Proxy to call AppD API.")
               proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
-              proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'])
-              proxy.use_ssl = true
+              proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'], :use_ssl => true)
               res = proxy.start(events_uri.host, events_uri.port) do |http|
                 http.request(request)
               end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -19,6 +19,7 @@ require 'net/http'
 require 'uri'
 require 'java_buildpack/component/versioned_dependency_component'
 require 'java_buildpack/framework'
+require 'java_buildpack/logging/logger_factory'
 
 module JavaBuildpack
   module Framework

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -19,7 +19,7 @@ require 'net/http'
 require 'uri'
 require 'java_buildpack/component/versioned_dependency_component'
 require 'java_buildpack/framework'
-require 'java_buildpack/logging/logger_factory'g
+require 'java_buildpack/logging/logger_factory'
 
 module JavaBuildpack
   module Framework

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -114,10 +114,12 @@ module JavaBuildpack
               @logger.debug("Using Proxy to call AppD API.")
               proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
               @logger.debug(proxy_credentials)
+              @logger.debug("Requesting> #{events_uri}")
               proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['username'], proxy_credentials['password'])
               res = proxy.start(events_uri.host, events_uri.port, :use_ssl => events_uri.scheme == 'https') do |http|
                 http.request(request)
               end
+              @logger.debug(res.code)
               @logger.debug(res.body)
             else
               sock = Net::HTTP.new(events_uri.host, events_uri.port)

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -57,6 +57,7 @@ module JavaBuildpack
 
         # Do Event Notification if we have API Credentials.
         if !@application.services.find_service(API_FILTER).nil?
+          print "----> Found AppD API Credentials.";
           deployment_notifier @application.services.find_service(API_FILTER)['credentials'], credentials
         end
       end
@@ -81,7 +82,7 @@ module JavaBuildpack
       # If api-user api-name are set on credenitals and appd-build set in env.
       # tell appd about this release.
       def deployment_notifier(api_credentials, credentials)
-        
+        print "----> Notifying AppD Of Deployment."
         if api_credentials['username'] and api_credentials['password']
             host_name = credentials['host-name']
             port = credentials['port']

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -110,16 +110,10 @@ module JavaBuildpack
               'severity' => 'INFO'
             })
 
-            if !proxy_credentials.nil?
-              @logger.debug("Using Proxy to call AppD API.")
-              proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'])
-              res = proxy.start(events_uri.host, events_uri.port) do |http|
-                http.request(request)
-              end
-            else
-              sock = Net::HTTP.new(events_uri.host, events_uri.port)
-              sock.use_ssl = true
-              res = sock.start { |http| http.request(request) }
+            @logger.debug("Using Proxy to call AppD API.")
+            proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'])
+            res = proxy.start(events_uri.host, events_uri.port) do |http|
+              http.request(request)
             end
         end
       end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -96,7 +96,7 @@ module JavaBuildpack
             host_name = credentials['host-name']
             port = credentials['port']
             app_name = credentials['application-name'] || @configuration['default_application_name'] || @application.details['application_name']
-            protocol = (credentials['ssl-enabled']) ? 'https' : 'http';
+            protocol = 'https';
             api_user = api_credentials['username']
             account = credentials['account-name']
             

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -57,7 +57,7 @@ module JavaBuildpack
 
         # Do Event Notification if we have API Credentials.
         if !@application.services.find_service(API_FILTER).nil?
-          deployment_notifier @application.services.find_service(API_FILTER)['credentials'] credentials
+          deployment_notifier @application.services.find_service(API_FILTER)['credentials'], credentials
         end
       end
 

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -101,14 +101,13 @@ module JavaBuildpack
             account = credentials['account-name']
             
             events_uri = URI.parse("#{protocol}://#{host_name}:#{port}/controller/rest/applications/#{app_name}/events")
-
+            
+            events_uri.query = URI.encode_www_form(['eventtype', 'APPLICATION_DEPLOYMENT'],
+              ['summary', "Deploying: #{app_name}",
+              ['severity', 'INFO'])
+              
             request = Net::HTTP::Post.new(events_uri.path)
             request.basic_auth "#{api_user}@#{account}", api_credentials['password']
-            request.set_form_data({
-              'eventtype' => 'APPLICATION_DEPLOYMENT',
-              'summary' => "Deploying: #{app_name}",
-              'severity' => 'INFO'
-            })
 
             if !@application.services.find_service(PROXY_FILTER).nil?
               @logger.debug("Using Proxy to call AppD API.")

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -100,7 +100,7 @@ module JavaBuildpack
             api_user = api_credentials['username']
             account = credentials['account-name']
             
-            events_uri = URI.parse("#{protocol}://#{host_name}:#{port}/#{app_name}/events")
+            events_uri = URI.parse("#{protocol}://#{host_name}:#{port}/controller/rest/applications/#{app_name}/events")
 
             request = Net::HTTP::Post.new(events_uri.path)
             request.basic_auth "#{api_user}@#{account}", api_credentials['password']
@@ -117,7 +117,7 @@ module JavaBuildpack
               res = proxy.start(events_uri.host, events_uri.port) do |http|
                 http.request(request)
               end
-              @logger.debug(res.body)
+              @logger.debug(res.body)g
             else
               sock = Net::HTTP.new(events_uri.host, events_uri.port)
               sock.use_ssl = true

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -54,7 +54,7 @@ module JavaBuildpack
           proxy_user java_opts, proxy_credentials
           proxy_password_file java_opts, proxy_credentials
         end
-        print "-----> Trying AppD Deployment Notification."
+        @logger.debug("-----> Trying AppD Deployment Notification.")
         # Do Event Notification if we have API Credentials.
         if !@application.services.find_service(API_FILTER).nil?
           deployment_notifier @application.services.find_service(API_FILTER)['credentials'], credentials
@@ -81,7 +81,7 @@ module JavaBuildpack
       # If api-user api-name are set on credenitals and appd-build set in env.
       # tell appd about this release.
       def deployment_notifier(api_credentials, credentials)
-        print "-----> Notifying AppD of Deployment."
+        @logger.debug("-----> Trying AppD Deployment Notification.")
         if api_credentials['username'] and api_credentials['password']
             host_name = credentials['host-name']
             port = credentials['port']

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -103,7 +103,7 @@ module JavaBuildpack
             events_uri = URI.parse("#{protocol}://#{host_name}:#{port}/controller/rest/applications/#{app_name}/events")
             
             events_uri.query = URI.encode_www_form(['eventtype', 'APPLICATION_DEPLOYMENT'],
-              ['summary', "Deploying: #{app_name}",
+              ['summary', "Deploying: #{app_name}"],
               ['severity', 'INFO'])
               
             request = Net::HTTP::Post.new(events_uri.path)

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -19,14 +19,21 @@ require 'net/http'
 require 'uri'
 require 'java_buildpack/component/versioned_dependency_component'
 require 'java_buildpack/framework'
-require 'java_buildpack/logging/logger_factory'
+require 'java_buildpack/logging/logger_factory'g
 
 module JavaBuildpack
   module Framework
 
     # Encapsulates the functionality for enabling zero-touch AppDynamics support.
     class AppDynamicsAgent < JavaBuildpack::Component::VersionedDependencyComponent
-
+      # Creates an instance
+      #
+      # @param [Hash] context a collection of utilities used the component
+      def initialize(context)
+        super(context)
+        @logger = JavaBuildpack::Logging::LoggerFactory.instance.get_logger AppDynamicsAgent
+      end
+      
       # (see JavaBuildpack::Component::BaseComponent#compile)
       def compile
         download_zip(false, @droplet.sandbox, 'AppDynamics Agent')
@@ -55,6 +62,7 @@ module JavaBuildpack
           proxy_user java_opts, proxy_credentials
           proxy_password_file java_opts, proxy_credentials
         end
+        
         @logger.debug("-----> Trying AppD Deployment Notification.")
         # Do Event Notification if we have API Credentials.
         if !@application.services.find_service(API_FILTER).nil?

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -113,8 +113,8 @@ module JavaBuildpack
             if !@application.services.find_service(PROXY_FILTER).nil?
               @logger.debug("Using Proxy to call AppD API.")
               proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
-              proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'], :use_ssl => true)
-              res = proxy.start(events_uri.host, events_uri.port) do |http|
+              proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'])
+              res = proxy.start(events_uri.host, events_uri.port, :use_ssl => events_uri.scheme == 'https') do |http|
                 http.request(request)
               end
               @logger.debug(res.body)

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -57,7 +57,6 @@ module JavaBuildpack
 
         # Do Event Notification if we have API Credentials.
         if !@application.services.find_service(API_FILTER).nil?
-          print "----> Found AppD API Credentials.";
           deployment_notifier @application.services.find_service(API_FILTER)['credentials'], credentials
         end
       end
@@ -82,7 +81,7 @@ module JavaBuildpack
       # If api-user api-name are set on credenitals and appd-build set in env.
       # tell appd about this release.
       def deployment_notifier(api_credentials, credentials)
-        print "----> Notifying AppD Of Deployment."
+        "---> Notifying AppD of Deployment."
         if api_credentials['username'] and api_credentials['password']
             host_name = credentials['host-name']
             port = credentials['port']
@@ -102,7 +101,7 @@ module JavaBuildpack
             
             sock = Net::HTTP.new(events_uri.host, events_uri.port)
             sock.use_ssl = true
-            res = sock.start { |http| http.request(req) }
+            res = sock.start { |http| http.request(request) }
             
         end
       end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -92,6 +92,7 @@ module JavaBuildpack
       def deployment_notifier(api_credentials, credentials)
         @logger.debug("-----> Trying AppD Deployment Notification.")
         if api_credentials['username'] and api_credentials['password']
+            @logger.debug("----> Making Request");
             host_name = credentials['host-name']
             port = credentials['port']
             app_name = credentials['application-name'] || @configuration['default_application_name'] || @application.details['application_name']
@@ -107,7 +108,9 @@ module JavaBuildpack
               'summary' => "Deploying: #{app_name}",
               'severity' => 'INFO'
             })
-            
+
+            @logger.debug(request)
+
             sock = Net::HTTP.new(events_uri.host, events_uri.port)
             sock.use_ssl = true
             res = sock.start { |http| http.request(request) }

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -110,7 +110,7 @@ module JavaBuildpack
               'severity' => 'INFO'
             })
 
-            if proxy_credentials
+            if !proxy_credentials.nil?
               @logger.debug("Using Proxy to call AppD API.")
               proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'])
               res = proxy.start(events_uri.host, events_uri.port) do |http|

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -95,7 +95,7 @@ module JavaBuildpack
             @logger.debug("----> Making Request");
             host_name = credentials['host-name']
             port = credentials['port']
-            app_name = credentials['application-name'] || @configuration['default_application_name'] || @application.details['application_name']
+            app_name = credentials['tier-name'] || @configuration['default_application_name'] || @application.details['application_name']
             protocol = 'https';
             api_user = api_credentials['username']
             account = credentials['account-name']
@@ -104,7 +104,7 @@ module JavaBuildpack
             
             events_uri.query = URI.encode_www_form(
             'eventtype' => 'APPLICATION_DEPLOYMENT',
-            'summary' => "Deploying: #{app_name}",
+            'summary' => URI.encode("Deploying: #{app_name}"),
             'severity' => 'INFO'
             )
               

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -109,7 +109,7 @@ module JavaBuildpack
             'severity' => 'INFO'
             )
               
-            request = Net::HTTP::Post.new(events_uri.path)
+            request = Net::HTTP::Post.new(events_uri.request_uri)
             request.basic_auth "#{api_user}@#{account}", api_credentials['password']
 
             if !@application.services.find_service(PROXY_FILTER).nil?

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -95,7 +95,7 @@ module JavaBuildpack
             @logger.debug("----> Making Request");
             host_name = credentials['host-name']
             port = credentials['port']
-            appd_name = credentials['app-name']
+            appd_name = credentials['application-name']
             app_name = credentials['tier-name'] || @configuration['default_application_name'] || @application.details['application_name']
             protocol = 'https';
             api_user = api_credentials['username']

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -102,9 +102,11 @@ module JavaBuildpack
             
             events_uri = URI.parse("#{protocol}://#{host_name}:#{port}/controller/rest/applications/#{app_name}/events")
             
-            events_uri.query = URI.encode_www_form(['eventtype', 'APPLICATION_DEPLOYMENT'],
-              ['summary', "Deploying: #{app_name}"],
-              ['severity', 'INFO'])
+            events_uri.query = URI.encode_www_form(
+            'eventtype' => 'APPLICATION_DEPLOYMENT',
+            'summary' => "Deploying: #{app_name}",
+            'severity' => 'INFO'
+            )
               
             request = Net::HTTP::Post.new(events_uri.path)
             request.basic_auth "#{api_user}@#{account}", api_credentials['password']

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -117,6 +117,7 @@ module JavaBuildpack
               res = proxy.start(events_uri.host, events_uri.port) do |http|
                 http.request(request)
               end
+              @logger.debug(res.body)
             else
               sock = Net::HTTP.new(events_uri.host, events_uri.port)
               sock.use_ssl = true

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -114,7 +114,7 @@ module JavaBuildpack
               @logger.debug("Using Proxy to call AppD API.")
               proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
               @logger.debug(proxy_credentials)
-              proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'])
+              proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['username'], proxy_credentials['password'])
               res = proxy.start(events_uri.host, events_uri.port, :use_ssl => events_uri.scheme == 'https') do |http|
                 http.request(request)
               end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -66,7 +66,8 @@ module JavaBuildpack
         @logger.debug("-----> Trying AppD Deployment Notification.")
         # Do Event Notification if we have API Credentials.
         if !@application.services.find_service(API_FILTER).nil?
-          deployment_notifier @application.services.find_service(API_FILTER)['credentials'], credentials, @application.services.find_service(PROXY_FILTER)['credentials']
+          proxy_credentials = @application.services.find_service(PROXY_FILTER)['credentials']
+          deployment_notifier @application.services.find_service(API_FILTER)['credentials'], credentials, proxy_credentials
         end
       end
 
@@ -110,7 +111,7 @@ module JavaBuildpack
               'severity' => 'INFO'
             })
 
-            if proxy_credentials
+            if !proxy_credentials
               @logger.debug("Using Proxy to call AppD API.")
               proxy = Net::HTTP::Proxy(proxy_credentials['host'], proxy_credentials['port'], proxy_credentials['user'], proxy_credentials['password'])
               res = proxy.start(events_uri.host, events_uri.port) do |http|

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -54,7 +54,7 @@ module JavaBuildpack
           proxy_user java_opts, proxy_credentials
           proxy_password_file java_opts, proxy_credentials
         end
-
+        print "-----> Trying AppD Deployment Notification."
         # Do Event Notification if we have API Credentials.
         if !@application.services.find_service(API_FILTER).nil?
           deployment_notifier @application.services.find_service(API_FILTER)['credentials'], credentials
@@ -81,7 +81,7 @@ module JavaBuildpack
       # If api-user api-name are set on credenitals and appd-build set in env.
       # tell appd about this release.
       def deployment_notifier(api_credentials, credentials)
-        "---> Notifying AppD of Deployment."
+        print "-----> Notifying AppD of Deployment."
         if api_credentials['username'] and api_credentials['password']
             host_name = credentials['host-name']
             port = credentials['port']

--- a/proxy.txt
+++ b/proxy.txt
@@ -1,3 +1,4 @@
+.appdynamics.com
 .newrelic.com
 .sky.com
 .bskyb.com


### PR DESCRIPTION
Requires a service bound to the app in the following format: 
`cf cups appd-api -p '{"username":"name@account","password":"password"}'`

Once bound provided both an AppD service is bound and proxy if required a deployment notification will be sent when the build pack hits the `release` step. 
